### PR TITLE
DLC support

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -90,6 +90,7 @@ name_casing=1
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=0
 quality/intended_usage/framebuffer_allocation.mobile=0
 quality/2d/use_pixel_snap=true

--- a/scripts/wardrobe.gd
+++ b/scripts/wardrobe.gd
@@ -9,34 +9,32 @@ onready var shirts_grid = $Shirts/ShirtsScroll/ShirtsGrid
 onready var undies_grid = $Underwear/UndiesScroll/UndiesGrid
 onready var accs_grid = $Accessoires/AccsScroll/AccsGrid
 
-func _ready():
-	var dlc_pack = "user://dlc/testdlc.pck"
-	var load_pck = ProjectSettings.load_resource_pack(dlc_pack, false)
+func get_dlc(dlc_pack, scenes: Array):
+	var usr_dir = "user://dlc/"
+	var dlc_path = usr_dir + dlc_pack
+	var load_pck = ProjectSettings.load_resource_pack(dlc_path, false)
+	print_debug("Loaded " + dlc_path + ": " + str(load_pck))
+	
+	# Check if the DLC is actually there
 	if load_pck == true:
-		ProjectSettings.load_resource_pack(dlc_pack, false)
-		var dir = Directory.new()
-		if dir.open("res://scenes/dlc/shirts") == OK:
-			dir.list_dir_begin()
-			var shirts = dir.get_next()
-			while shirts != "":
-				var shirt = "res://scenes/dlc/shirts/" + shirts
-				var inst = load(shirt).instance()
-				shirts_grid.add_child(inst)
-				inst.set_owner(self)
+		# Load the DLC
+		ProjectSettings.load_resource_pack(dlc_path, false)
+		
+		# Initialize and add nodes from each tab 
+		for scene in scenes:
+			var dlc_scene = "res://scenes/dlc/" + scene
+			var init = load(dlc_scene).instance()
+			
+			if "shirts" in scene:
+				shirts_grid.add_child(init)
+				print_debug("Initialized: " + dlc_scene)
 				
-#			var import_scene = load(shirts).instance()
-#			shirts_grid.add_child(import_scene)
-#	if dir.open("user://dlc") == OK:
-#		print_debug(OS.get_user_data_dir())
-#		dir.list_dir_begin()
-#		var load_pcks = ProjectSettings.load_resource_pack(dir.get_next(), false)
-#		if load_pcks == true:
-#			if dir.change_dir("res://scenes/dlc/shirts") == OK:
-#				var file_name = dir.get_next()
-#				print_debug("loaded:" + file_name)
-#				if dir.current_is_dir() == "shirts":
-#					var shirt_dlc = load(dir.get_next())
-#					shirts_grid.get_children(shirt_dlc)
+			if "pants" in scene:
+				pants_grid.add_child(init)
+				print_debug("Initialized: " + dlc_scene)
+
+func _ready():
+	get_dlc("testdlc.pck", ["shirts/TestShirts.tscn"])
 			
 func _on_removeAccessory_pressed():
 	character.accessory = blank_top

--- a/scripts/wardrobe.gd
+++ b/scripts/wardrobe.gd
@@ -9,7 +9,24 @@ onready var shirts_grid = $Shirts/ShirtsScroll/ShirtsGrid
 onready var undies_grid = $Underwear/UndiesScroll/UndiesGrid
 onready var accs_grid = $Accessoires/AccsScroll/AccsGrid
 
-func get_dlc(dlc_pack, scenes: Array):
+func list_files_in_directory(path):
+	var files = []
+	var dir = Directory.new()
+	dir.open(path)
+	dir.list_dir_begin()
+
+	while true:
+		var file = dir.get_next()
+		if file == "":
+			break
+		elif not file.begins_with("."):
+			files.append(file)
+
+	dir.list_dir_end()
+
+	return files
+
+func check_for_dlc(dlc_pack):
 	var usr_dir = "user://dlc/"
 	var dlc_path = usr_dir + dlc_pack
 	var load_pck = ProjectSettings.load_resource_pack(dlc_path, false)
@@ -20,21 +37,38 @@ func get_dlc(dlc_pack, scenes: Array):
 		# Load the DLC
 		ProjectSettings.load_resource_pack(dlc_path, false)
 		
-		# Initialize and add nodes from each tab 
-		for scene in scenes:
-			var dlc_scene = "res://scenes/dlc/" + scene
-			var init = load(dlc_scene).instance()
-			
-			if "shirts" in scene:
+		# Locates 
+		var dir = Directory.new()
+		dir.list_dir_begin()
+		var shirts_dir = "res://scenes/dlc/shirts/"
+		var pants_dir = "res://scenes/dlc/pants/"
+		var undies_dir = "res://scenes/dlc/undies/"
+		var dlc_shirts = list_files_in_directory(shirts_dir)
+		var dlc_pants = list_files_in_directory(pants_dir)
+		var dlc_undies = list_files_in_directory(undies_dir)
+		
+		# Initialize and add nodes from each tab
+		for shirt in dlc_shirts:
+			if dir.file_exists(shirts_dir + shirt):
+				var init = load(shirts_dir + shirt).instance()
 				shirts_grid.add_child(init)
-				print_debug("Initialized: " + dlc_scene)
+				print_debug("Initialized: " + shirts_dir + shirt)
 				
-			if "pants" in scene:
-				pants_grid.add_child(init)
-				print_debug("Initialized: " + dlc_scene)
+		for pants in dlc_pants:
+			if dir.file_exists(pants_dir + pants):
+				var init = load(pants_dir + pants).instance()
+				shirts_grid.add_child(init)
+				print_debug("Initialized: " + pants_dir + pants)
+	
+		for undies in dlc_undies:
+			if dir.file_exists(undies_dir + undies):
+				var init = load(undies_dir + undies).instance()
+				shirts_grid.add_child(init)
+				print_debug("Initialized: " + undies_dir + undies)
 
 func _ready():
-	get_dlc("testdlc.pck", ["shirts/TestShirts.tscn"])
+#	check_for_dlc("testdlc.pck")
+	pass
 			
 func _on_removeAccessory_pressed():
 	character.accessory = blank_top

--- a/scripts/wardrobe.gd
+++ b/scripts/wardrobe.gd
@@ -34,12 +34,14 @@ func check_for_dlc(dlc_pack):
 	
 	# Check if the DLC is actually there
 	if load_pck == true:
-		# Load the DLC
+		
+		# Loads the DLC
 		ProjectSettings.load_resource_pack(dlc_path, false)
 		
-		# Locates 
 		var dir = Directory.new()
 		dir.list_dir_begin()
+		
+		# Lists the files in each of their respective directories
 		var shirts_dir = "res://scenes/dlc/shirts/"
 		var pants_dir = "res://scenes/dlc/pants/"
 		var undies_dir = "res://scenes/dlc/undies/"
@@ -47,7 +49,8 @@ func check_for_dlc(dlc_pack):
 		var dlc_pants = list_files_in_directory(pants_dir)
 		var dlc_undies = list_files_in_directory(undies_dir)
 		
-		# Initialize and add nodes from each tab
+		# Make sure each file actually exist, instance them
+		# and add them to their respective tabs
 		for shirt in dlc_shirts:
 			if dir.file_exists(shirts_dir + shirt):
 				var init = load(shirts_dir + shirt).instance()

--- a/scripts/wardrobe.gd
+++ b/scripts/wardrobe.gd
@@ -4,6 +4,20 @@ onready var character = preload("res://resources/character.tres")
 onready var blank_top = preload("res://sprites/clothes/blank_top.png")
 onready var blank_bottom = preload("res://sprites/clothes/blank_bottom.png")
 
+onready var pants_grid = $Pants/PantsScroll/PantsGrid
+onready var shirts_grid = $Shirts/ShirtsScroll/ShirtsGrid
+onready var undies_grid = $Underwear/UndiesScroll/UndiesGrid
+onready var accs_grid = $Accessoires/AccsScroll/AccsGrid
+
+func _ready():
+	var load_pck = ProjectSettings.load_resource_pack("user://dlc/pack.pck")
+	
+	if load_pck == true:
+		# All the button scenes are consolidated 
+		# in a root scene and and each parent 
+		# is instanced to their respective grid
+		var import_scene = load("res://scenes/dlc/pants.tscn")
+			
 func _on_removeAccessory_pressed():
 	character.accessory = blank_top
 

--- a/scripts/wardrobe.gd
+++ b/scripts/wardrobe.gd
@@ -10,13 +10,19 @@ onready var undies_grid = $Underwear/UndiesScroll/UndiesGrid
 onready var accs_grid = $Accessoires/AccsScroll/AccsGrid
 
 func _ready():
-	var load_pck = ProjectSettings.load_resource_pack("user://dlc/pack.pck")
+	var dir = Directory.new()
 	
-	if load_pck == true:
-		# All the button scenes are consolidated 
-		# in a root scene and and each parent 
-		# is instanced to their respective grid
-		var import_scene = load("res://scenes/dlc/pants.tscn")
+	if dir.open("user://dlc") == OK:
+		dir.list_dir_begin()
+		if "pck" in dir.get_next() == true:
+			var load_pcks = ProjectSettings.load_resource_pack(dir.get_next(), false)
+			if load_pcks == true:
+				if dir.open("res://scenes/dlc") == OK:
+					var file_name = dir.get_next()
+					dir.change_dir("shirts")
+					if dir.current_is_dir() == "shirts":
+						var shirt_dlc = load(dir.get_next())
+						shirts_grid.get_children(shirt_dlc)
 			
 func _on_removeAccessory_pressed():
 	character.accessory = blank_top

--- a/scripts/wardrobe.gd
+++ b/scripts/wardrobe.gd
@@ -10,19 +10,33 @@ onready var undies_grid = $Underwear/UndiesScroll/UndiesGrid
 onready var accs_grid = $Accessoires/AccsScroll/AccsGrid
 
 func _ready():
-	var dir = Directory.new()
-	
-	if dir.open("user://dlc") == OK:
-		dir.list_dir_begin()
-		if "pck" in dir.get_next() == true:
-			var load_pcks = ProjectSettings.load_resource_pack(dir.get_next(), false)
-			if load_pcks == true:
-				if dir.open("res://scenes/dlc") == OK:
-					var file_name = dir.get_next()
-					dir.change_dir("shirts")
-					if dir.current_is_dir() == "shirts":
-						var shirt_dlc = load(dir.get_next())
-						shirts_grid.get_children(shirt_dlc)
+	var dlc_pack = "user://dlc/testdlc.pck"
+	var load_pck = ProjectSettings.load_resource_pack(dlc_pack, false)
+	if load_pck == true:
+		ProjectSettings.load_resource_pack(dlc_pack, false)
+		var dir = Directory.new()
+		if dir.open("res://scenes/dlc/shirts") == OK:
+			dir.list_dir_begin()
+			var shirts = dir.get_next()
+			while shirts != "":
+				var shirt = "res://scenes/dlc/shirts/" + shirts
+				var inst = load(shirt).instance()
+				shirts_grid.add_child(inst)
+				inst.set_owner(self)
+				
+#			var import_scene = load(shirts).instance()
+#			shirts_grid.add_child(import_scene)
+#	if dir.open("user://dlc") == OK:
+#		print_debug(OS.get_user_data_dir())
+#		dir.list_dir_begin()
+#		var load_pcks = ProjectSettings.load_resource_pack(dir.get_next(), false)
+#		if load_pcks == true:
+#			if dir.change_dir("res://scenes/dlc/shirts") == OK:
+#				var file_name = dir.get_next()
+#				print_debug("loaded:" + file_name)
+#				if dir.current_is_dir() == "shirts":
+#					var shirt_dlc = load(dir.get_next())
+#					shirts_grid.get_children(shirt_dlc)
 			
 func _on_removeAccessory_pressed():
 	character.accessory = blank_top


### PR DESCRIPTION
This update adds support for loading in DLC using the ``check_for_dlc()`` function. New clothes and accessories are added by searching through ``"res://scenes/dlc/shirts/"`` directory, for example, and added to the respective tab in the wardrobe as if it were part of the base game. It's not the best solution in the world but it works.

I've created a [Github template](https://github.com/tonytins/tonysdressupdlc) to make it easier for myself or anyone else to spin up their own DLC. It's licensed under the MIT license because these packs are basically the equivalent of libraries.